### PR TITLE
docs: add repository badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # @kingstinct/react-native-activity-kit
 
+[![Test Status](https://github.com/Kingstinct/react-native-activity-kit/actions/workflows/test.yml/badge.svg)](https://github.com/Kingstinct/react-native-activity-kit/actions/workflows/test.yml)
+[![Latest version on NPM](https://img.shields.io/npm/v/@kingstinct/react-native-activity-kit)](https://www.npmjs.com/package/@kingstinct/react-native-activity-kit)
+[![Downloads on NPM](https://img.shields.io/npm/dt/@kingstinct/react-native-activity-kit)](https://www.npmjs.com/package/@kingstinct/react-native-activity-kit)
+[![Discord](https://dcbadge.limes.pink/api/server/hrgnETpsJA?style=flat)](https://discord.gg/hrgnETpsJA)
+
 A powerful React Native library for iOS Live Activities using ActivityKit, built with Nitro Modules for optimal performance.
 
 ## 📱 Features


### PR DESCRIPTION
## Summary
- add badges for CI status, npm stats, and Discord

## Testing
- `bun test`
- `bun run lint`
- `bun run typecheck && echo 'typecheck passed'`


------
https://chatgpt.com/codex/tasks/task_e_68960a1f1df0832d95d8e58579edf336