### PR TITLE
feat: add support for scheduled Live Activities via `startDate`

### DIFF
--- a/packages/react-native-activity-kit/ios/ActivityKitModule.swift
+++ b/packages/react-native-activity-kit/ios/ActivityKitModule.swift
@@ -112,9 +112,14 @@ class ActivityKitModule: HybridActivityKitModuleSpec {
                 pushType = nil
             }
 
+            let attributeDict = anyMapToDictionary(attributes)
+            let scheduledStartTimestamp = attributeDict["_startDate"] as? Double
+            let scheduledAlertTitle = attributeDict["_alertTitle"] as? String
+            let scheduledAlertBody = attributeDict["_alertBody"] as? String
+
             let state = try ActivityKitModuleAttributes.ContentState(data: anyMapToDictionary(state))
 
-            let attributes = try ActivityKitModuleAttributes(data: anyMapToDictionary(attributes))
+            let attributes = try ActivityKitModuleAttributes(data: attributeDict)
 
             var activity: Activity<ActivityKitModuleAttributes>
 
@@ -125,7 +130,22 @@ class ActivityKitModule: HybridActivityKitModuleSpec {
                     relevanceScore: options?.relevanceScore ?? 0,
                 )
 
-                if #available(iOS 18.0, *) {
+                if let startTimestamp = scheduledStartTimestamp {
+                    let startDate = Date(timeIntervalSince1970: startTimestamp / 1000)
+                    let alertConfig = ActivityKit.AlertConfiguration(
+                        title: LocalizedStringResource(stringLiteral: scheduledAlertTitle ?? "Live Activity Started"),
+                        body: LocalizedStringResource(stringLiteral: scheduledAlertBody ?? "Tap to open"),
+                        sound: .default
+                    )
+                    activity = try Activity.request(
+                        attributes: attributes,
+                        content: content,
+                        pushType: pushType,
+                        style: options?.style == .transient ? .transient : .standard,
+                        alertConfiguration: alertConfig,
+                        startDate: startDate
+                    )
+                } else if #available(iOS 18.0, *) {
                     activity = try Activity.request(
                         attributes: attributes,
                         content: content,

--- a/packages/react-native-activity-kit/ios/ActivityKitModule.swift
+++ b/packages/react-native-activity-kit/ios/ActivityKitModule.swift
@@ -137,14 +137,25 @@ class ActivityKitModule: HybridActivityKitModuleSpec {
                         body: LocalizedStringResource(stringLiteral: scheduledAlertBody ?? "Tap to open"),
                         sound: .default
                     )
-                    activity = try Activity.request(
-                        attributes: attributes,
-                        content: content,
-                        pushType: pushType,
-                        style: options?.style == .transient ? .transient : .standard,
-                        alertConfiguration: alertConfig,
-                        startDate: startDate
-                    )
+                    if #available(iOS 26.0, *) {
+                        activity = try Activity.request(
+                            attributes: attributes,
+                            content: content,
+                            pushType: pushType,
+                            style: options?.style == .transient ? .transient : .standard,
+                            alertConfiguration: alertConfig,
+                            start: startDate
+                        )
+                    } else {
+                        activity = try Activity.request(
+                            attributes: attributes,
+                            content: content,
+                            pushType: pushType,
+                            style: options?.style == .transient ? .transient : .standard,
+                            alertConfiguration: alertConfig,
+                            startDate: startDate
+                        )
+                    }
                 } else if #available(iOS 18.0, *) {
                     activity = try Activity.request(
                         attributes: attributes,


### PR DESCRIPTION
# feat: add support for scheduled Live Activities via `startDate`

Adds support for Apple's [`Activity.request(startDate:)`](https://developer.apple.com/documentation/activitykit/activity/request(attributes:content:pushtype:style:alertconfiguration:startdate:)) API, allowing Live Activities to be scheduled to appear at a future date instead of immediately. Requires **iOS 17.2+**. Fully backward-compatible.

Handles the iOS 26.0 deprecation — uses the new `start:` parameter on iOS 26+ and falls back to `startDate:` on earlier versions.

## How it works

Three reserved attribute keys (prefixed with `_` to avoid collisions):

| Key | Type | Description |
|-----|------|-------------|
| `_startDate` | `Double` | Unix timestamp (ms) — when the activity should appear |
| `_alertTitle` | `String` | Notification title shown at start |
| `_alertBody` | `String` | Notification body text |

When `_startDate` is present, `Activity.request(startDate:)` is called with an `AlertConfiguration`. When absent, existing behavior is preserved.

## Usage

```typescript
ActivityKit.startActivity(
  {
    name: "My Activity",
    _startDate: Date.now() + 1000 * 60 * 30, // 30 min from now
    _alertTitle: "Activity is Live!",
    _alertBody: "Tap to open",
  },
  contentState,
  options
);
```

## Use case

Schedule Live Activity state transitions on-device — no server push, no background tasks. Example: start a countdown now, schedule a "LIVE" activity to appear automatically at the target time.

Use case: I was struggling to change a counter to show a simple text after the countdown reaches zero, using two live activities scheduled instead of just one, did the job just right! This way we can transition between states easily. 

Working example:
https://github.com/user-attachments/assets/dc4f84ef-32d5-4e85-bfea-3f3d69732dbe



